### PR TITLE
Standardize links styling across pages

### DIFF
--- a/src/components/MonsterCard.js
+++ b/src/components/MonsterCard.js
@@ -1,4 +1,4 @@
-import { Box, Card, Link as RadixLink, Text } from "@radix-ui/themes"
+import { Box, Card, Text } from "@radix-ui/themes"
 import { Link } from "react-router-dom";
 import apiClient from "../api/apiClient";
 

--- a/src/components/MonsterCard.js
+++ b/src/components/MonsterCard.js
@@ -1,4 +1,4 @@
-import { Box, Card, Text } from "@radix-ui/themes"
+import { Box, Card, Link as RadixLink, Text } from "@radix-ui/themes"
 import { Link } from "react-router-dom";
 import apiClient from "../api/apiClient";
 
@@ -7,7 +7,7 @@ function MonsterCard({monsterID, monsterOldName, monsterFamily}) {
   
   return (
     <Box width="125px" margin="10px">
-      <Card asChild>
+      <Card asChild className="group hover:shadow-md hover:shadow-black/20 transition-shadow duration-300 hover:outline hover:outline-2 hover:outline-blue-500">
         <Link key={monsterID} to={`${monsterID}`}>
           <img 
             src={imageURL} 
@@ -18,10 +18,10 @@ function MonsterCard({monsterID, monsterOldName, monsterFamily}) {
               width: '100%'
             }}
           />
-          <Text as="div">
+          <Text as="div" weight={"bold"} color="blue" className="group-hover:underline">
             {monsterOldName}
           </Text>
-          <Text as="div">
+          <Text as="div" color="blue" className="group-hover:underline">
             {monsterFamily}
           </Text>
         </Link>

--- a/src/pages/MonsterProfilePage.js
+++ b/src/pages/MonsterProfilePage.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link, useParams } from "react-router-dom";
 import { fetchBreedingInfo, fetchMonsterDetail } from "../api/monsterInfoAPI"
 import apiClient from "../api/apiClient";
-import { Card, Container, Flex, Heading, Table, Text } from "@radix-ui/themes"
+import { Card, Container, Flex, Heading, Link as RadixLink, Table, Text } from "@radix-ui/themes"
 
 function MonsterProfilePage() {
   const params = useParams();
@@ -63,7 +63,9 @@ function MonsterProfilePage() {
               {monster.skills.map(skill => (
                 <Table.Row>
                   <Table.Cell>
-                    <Link to={`/dqm1/skills/${skill.id}`}>{skill.old_name} </Link>
+                    <RadixLink asChild weight={"bold"}>
+                      <Link to={`/dqm1/skills/${skill.id}`}>{skill.old_name} </Link>
+                    </RadixLink>
                   </Table.Cell>
                   <Table.Cell>
                     <Text>{skill.description}</Text>
@@ -91,9 +93,11 @@ function MonsterProfilePage() {
                   <Table.Cell>
                     {combo.pedigree ? (
                       combo.pedigree_id !== monster.id ? (
-                        <Link to={`/dqm1/monsterlist/${combo.pedigree_id}`}>
-                          {combo.pedigree.old_name}
-                        </Link>
+                        <RadixLink asChild weight={"bold"}>
+                          <Link to={`/dqm1/monsterlist/${combo.pedigree_id}`}>
+                            {combo.pedigree.old_name}
+                          </Link>
+                        </RadixLink>
                       ) : (
                         combo.pedigree.old_name
                       )
@@ -107,9 +111,11 @@ function MonsterProfilePage() {
                   <Table.Cell>
                     {combo.parent2 ? (
                       combo.parent2_id !== monster.id ? (
-                        <Link to={`/dqm1/monsterlist/${combo.parent2_id}`}>
-                          {combo.parent2.old_name}
-                        </Link>
+                        <RadixLink asChild weight={"bold"}>
+                          <Link to={`/dqm1/monsterlist/${combo.parent2_id}`}>
+                            {combo.parent2.old_name}
+                          </Link>
+                        </RadixLink>
                       ) : (
                       combo.parent2.old_name
                       )
@@ -122,9 +128,11 @@ function MonsterProfilePage() {
                     
                   <Table.Cell>
                     {combo.child_id !== monster.id ? (
-                      <Link to={`/dqm1/monsterlist/${combo.child_id}`}>
-                        {combo.child.old_name}
-                      </Link>
+                      <RadixLink asChild weight={"bold"}>
+                        <Link to={`/dqm1/monsterlist/${combo.child_id}`}>
+                          {combo.child.old_name}
+                        </Link>
+                      </RadixLink>
                     ) : (
                       combo.child.old_name
                     )}

--- a/src/pages/SkillListPage.js
+++ b/src/pages/SkillListPage.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react"
 import { Link } from "react-router-dom";
 import { fetchSkillsList } from "../api/monsterSkillAPI.js"
-import { Box, Container, Flex, Heading, Select, Strong, Table } from "@radix-ui/themes"
+import { Box, Container, Flex, Heading, Link as RadixLink, Select, Strong, Table } from "@radix-ui/themes"
 
 function SkillListPage() {
   const [skills, setSkills] = useState([]);
@@ -90,9 +90,11 @@ function SkillListPage() {
           {filteredSkills.map(skill => (
             <Table.Row key={skill.id}>
               <Table.RowHeaderCell>
-                <Link key={skill.id} to={`${skill.id}`}>
-                  {skill.old_name}
-                </Link>
+                <RadixLink asChild weight={"bold"}>
+                  <Link key={skill.id} to={`${skill.id}`}>
+                    {skill.old_name}
+                  </Link>
+                </RadixLink>
               </Table.RowHeaderCell>
               <Table.Cell>{skill.category_type}</Table.Cell>
               <Table.Cell>{skill.family_type}</Table.Cell>

--- a/src/pages/SkillListPage.js
+++ b/src/pages/SkillListPage.js
@@ -41,7 +41,7 @@ function SkillListPage() {
 
   const categoryDropdown = (
     <Select.Root onValueChange={handleCategoryChange}>
-      <Select.Trigger placeholder="skill category"/>
+      <Select.Trigger placeholder="Skill Category"/>
       <Select.Content>
         <Select.Group>
           <Select.Label>Category</Select.Label>
@@ -55,10 +55,10 @@ function SkillListPage() {
 
   const skillfamilyDropdown = (
     <Select.Root onValueChange={handleFamilyChange}>
-      <Select.Trigger placeholder="skill family"/>
+      <Select.Trigger placeholder="Skill Family"/>
       <Select.Content>
         <Select.Group>
-          <Select.Label>Location</Select.Label>
+          <Select.Label>Family</Select.Label>
           {skillfamilies.map(family => (
             <Select.Item key={family} value={family}>{family}</Select.Item>
           ))}

--- a/src/pages/SkillListPage.js
+++ b/src/pages/SkillListPage.js
@@ -82,7 +82,7 @@ function SkillListPage() {
             <Table.ColumnHeaderCell>Category</Table.ColumnHeaderCell>
             <Table.ColumnHeaderCell>Family</Table.ColumnHeaderCell>
             <Table.ColumnHeaderCell>Description</Table.ColumnHeaderCell>
-            <Table.ColumnHeaderCell>MP Cost</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell minWidth={"100px"}>MP Cost</Table.ColumnHeaderCell>
           </Table.Row>
         </Table.Header>
 

--- a/src/pages/SkillProfilePage.js
+++ b/src/pages/SkillProfilePage.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams } from "react-router-dom";
 import { fetchSkillDetail } from "../api/monsterSkillAPI.js"
-import { Container, Flex, Heading, Strong, Table } from "@radix-ui/themes"
+import { Container, Flex, Heading, Link as RadixLink, Strong, Table } from "@radix-ui/themes"
 
 function SkillProfilePage() {
   const params = useParams();
@@ -64,9 +64,11 @@ function SkillProfilePage() {
             <Table.Row>
               <Table.Cell><Strong>Upgrades From</Strong></Table.Cell>
               <Table.Cell>
-                <Link to={`/dqm1/skills/${skill.upgrade_from.id}`}>
-                  {skill.upgrade_from.old_name}
-                </Link>
+                <RadixLink asChild weight={"bold"}>
+                  <Link to={`/dqm1/skills/${skill.upgrade_from.id}`}>
+                    {skill.upgrade_from.old_name}
+                  </Link>
+                </RadixLink>
               </Table.Cell>
             </Table.Row>
           )}
@@ -74,9 +76,11 @@ function SkillProfilePage() {
             <Table.Row>
               <Table.Cell><Strong>Upgrades To</Strong></Table.Cell>
               <Table.Cell>
-                <Link to={`/dqm1/skills/${skill.upgrade_to.id}`}>
-                  {skill.upgrade_to.old_name}
-                </Link>
+                <RadixLink asChild weight={"bold"}>
+                  <Link to={`/dqm1/skills/${skill.upgrade_to.id}`}>
+                    {skill.upgrade_to.old_name}
+                  </Link>
+                </RadixLink>
               </Table.Cell>
             </Table.Row>
           )}


### PR DESCRIPTION
- Used Link component from Radix UI's theme. Since "Link" name is taken for react-router-dom, we're using RadixLink
- On hover, the clickable elements are highlighted
- Several different places had unstylized links including the below. This made it difficult for the user to know if certain text were clickable.
    - MonsterCard.js
    - MonsterListPage.js
    - MonsterProfilePage.js
    - SkillListPage.js 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced visual styling and interactivity of monster cards, including improved hover effects and text emphasis.
  - Updated dropdown and table styles for skill lists, including improved placeholder text and column sizing.
  - Applied consistent bold styling to specific links across profile and list pages for a more unified appearance.

- **New Features**
  - Improved link appearance and behavior by integrating Radix UI styling with navigation links throughout profile and list pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->